### PR TITLE
A lot of small cleanups in the plugin to remove the compile time warnings

### DIFF
--- a/Source/modio/Private/Schemas/FModioMod.cpp
+++ b/Source/modio/Private/Schemas/FModioMod.cpp
@@ -2,6 +2,7 @@
 // Released under MIT.
 
 #include "FModioMod.h"
+#include "FModioMetadataKVP.h"
 
 void InitializeMod(FModioMod &mod, const modio::Mod &modio_mod)
 {

--- a/Source/modio/Private/Schemas/FModioModfile.cpp
+++ b/Source/modio/Private/Schemas/FModioModfile.cpp
@@ -2,6 +2,7 @@
 // Released under MIT.
 
 #include "FModioModfile.h"
+#include "Schemas/FModioFilehash.h"
 
 void InitializeModfile(FModioModfile &Modfile, const modio::Modfile &modio_modfile)
 {

--- a/Source/modio/Private/UModioFunctionLibrary.cpp
+++ b/Source/modio/Private/UModioFunctionLibrary.cpp
@@ -3,7 +3,7 @@
 
 #include "UModioFunctionLibrary.h"
 #include "UModioComponent.h"
-#include "modio.h"
+#include "ModioHWrapper.h"
 
 extern modio::Instance *modio_instance;
 

--- a/Source/modio/Private/UModioFunctionLibrary.cpp
+++ b/Source/modio/Private/UModioFunctionLibrary.cpp
@@ -2,6 +2,10 @@
 // Released under MIT.
 
 #include "UModioFunctionLibrary.h"
+#include "UModioComponent.h"
+#include "modio.h"
+
+extern modio::Instance *modio_instance;
 
 UModioFunctionLibrary::UModioFunctionLibrary(const FObjectInitializer &ObjectInitializer)
     : Super(ObjectInitializer)

--- a/Source/modio/Public/FModioModule.h
+++ b/Source/modio/Public/FModioModule.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "Runtime/Core/Public/Modules/ModuleManager.h"
+#include "Modules/ModuleManager.h"
 #include "modio.h"
 #include "ModioUE4Utility.h"
 #include "UModioComponent.h"

--- a/Source/modio/Public/FModioModule.h
+++ b/Source/modio/Public/FModioModule.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "Modules/ModuleManager.h"
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "ModioUE4Utility.h"
 #include "UModioComponent.h"
 #include "UModioSettings.h"

--- a/Source/modio/Public/ModioHWrapper.h
+++ b/Source/modio/Public/ModioHWrapper.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "Windows/PreWindowsApi.h"
+#ifndef STRICT
+#define STRICT
+#endif
+#include "modio.h"
+#include "Windows/PostWindowsApi.h"

--- a/Source/modio/Public/ModioUE4Utility.h
+++ b/Source/modio/Public/ModioUE4Utility.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "ModioUE4Plugin.h"
 
 extern TArray<FModioMod> toTArrayMods(const std::vector<modio::Mod> &modio_mods);

--- a/Source/modio/Public/Schemas/FModioAvatar.h
+++ b/Source/modio/Public/Schemas/FModioAvatar.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioAvatar.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/modio/Public/Schemas/FModioDownload.h
+++ b/Source/modio/Public/Schemas/FModioDownload.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioDownload.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/modio/Public/Schemas/FModioFilehash.h
+++ b/Source/modio/Public/Schemas/FModioFilehash.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioFilehash.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/modio/Public/Schemas/FModioFilehash.h
+++ b/Source/modio/Public/Schemas/FModioFilehash.h
@@ -16,4 +16,4 @@ struct FModioFilehash
 };
 
 extern void InitializeFilehash(FModioFilehash &filehash, const modio::Filehash &modio_filehash);
-extern void InitializeFileHashC(FModioFilehash &filehash, const ModioFilehash &modio_filehash);
+extern void InitializeFilehashC(FModioFilehash &filehash, const ModioFilehash &modio_filehash);

--- a/Source/modio/Public/Schemas/FModioImage.h
+++ b/Source/modio/Public/Schemas/FModioImage.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioImage.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/modio/Public/Schemas/FModioInstalledMod.h
+++ b/Source/modio/Public/Schemas/FModioInstalledMod.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioMod.h"
 #include "FModioInstalledMod.generated.h"
 

--- a/Source/modio/Public/Schemas/FModioLogo.h
+++ b/Source/modio/Public/Schemas/FModioLogo.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioLogo.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/modio/Public/Schemas/FModioMedia.h
+++ b/Source/modio/Public/Schemas/FModioMedia.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioImage.h"
 #include "FModioMedia.generated.h"
 

--- a/Source/modio/Public/Schemas/FModioMetadataKVP.h
+++ b/Source/modio/Public/Schemas/FModioMetadataKVP.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioMetadataKVP.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/modio/Public/Schemas/FModioMetadataKVP.h
+++ b/Source/modio/Public/Schemas/FModioMetadataKVP.h
@@ -17,5 +17,5 @@ struct FModioMetadataKVP
   FString Metavalue;
 };
 
-extern void InitializeKVP(FModioMetadataKVP &metadata_kvp, const modio::MetadataKVP &modio_metadata_kvp);
-extern void InitializeKVPC(FModioMetadataKVP &metadata_kvp, const ModioMetadataKVP &modio_metadata_kvp);
+extern void InitializeMetadataKVP( FModioMetadataKVP &MetadataKVP, const modio::MetadataKVP &modio_metadata_kvp );
+extern void InitializeMetadataKVPC( FModioMetadataKVP &MetadataKVP, const ModioMetadataKVP &modio_metadata_kvp );

--- a/Source/modio/Public/Schemas/FModioMod.h
+++ b/Source/modio/Public/Schemas/FModioMod.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioLogo.h"
 #include "FModioUser.h"
 #include "FModioModfile.h"

--- a/Source/modio/Public/Schemas/FModioModfile.h
+++ b/Source/modio/Public/Schemas/FModioModfile.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioFilehash.h"
 #include "FModioDownload.h"
 #include "FModioModfile.generated.h"

--- a/Source/modio/Public/Schemas/FModioQueuedModDownload.h
+++ b/Source/modio/Public/Schemas/FModioQueuedModDownload.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioMod.h"
 #include "FModioQueuedModDownload.generated.h"
 

--- a/Source/modio/Public/Schemas/FModioQueuedModfileUpload.h
+++ b/Source/modio/Public/Schemas/FModioQueuedModfileUpload.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioQUeuedModfileUpload.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/modio/Public/Schemas/FModioStats.h
+++ b/Source/modio/Public/Schemas/FModioStats.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioStats.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/modio/Public/Schemas/FModioTag.h
+++ b/Source/modio/Public/Schemas/FModioTag.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioTag.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/modio/Public/Schemas/FModioUser.h
+++ b/Source/modio/Public/Schemas/FModioUser.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "modio.h"
+#include "ModioHWrapper.h"
 #include "FModioAvatar.h"
 #include "FModioUser.generated.h"
 

--- a/Source/modio/Public/UModioComponent.h
+++ b/Source/modio/Public/UModioComponent.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "Runtime/Engine/Classes/Components/ActorComponent.h"
+#include "Components/ActorComponent.h"
 #include "ModioUE4Plugin.h"
 
 #include "UModioComponent.generated.h"

--- a/Source/modio/Public/UModioFunctionLibrary.h
+++ b/Source/modio/Public/UModioFunctionLibrary.h
@@ -3,6 +3,14 @@
 
 #pragma once
 
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "Enums/EModioFilterType.h"
+#include "Customizables/FModioModfileCreator.h"
+#include "Customizables/FModioModEditor.h"
+#include "Customizables/FModioModCreator.h"
+#include "Schemas/FModioQueuedModfileUpload.h"
+#include "Schemas/FModioQueuedModDownload.h"
+#include "Schemas/FModioInstalledMod.h"
 #include "UModioFunctionLibrary.generated.h"
 
 UCLASS()

--- a/Source/modio/Public/UModioSettings.h
+++ b/Source/modio/Public/UModioSettings.h
@@ -3,9 +3,6 @@
 
 #pragma once
 
-#include "Developer/Settings/Public/ISettingsModule.h"
-#include "Developer/Settings/Public/ISettingsSection.h"
-#include "Developer/Settings/Public/ISettingsContainer.h"
 #include "UModioSettings.generated.h"
 
 UCLASS(config = Game, defaultconfig)

--- a/Source/modio/modio.Build.cs
+++ b/Source/modio/modio.Build.cs
@@ -32,14 +32,14 @@ public class modio : ModuleRules
 
 		LoadModio(Target);
 
-		this.bEnableExceptions = true;
+		bEnableExceptions = true;
 		// Made sure to disable unity builds, as exclusion of some files causes the project to explode
 		// this was we atleast get deterministic builds even if they are slower
 		MinSourceFilesForUnityBuildOverride = 256;
 		
 		PublicIncludePaths.AddRange(
 			new string[] {
-				"modio/Public"
+				//"modio/Public"
 				/*,
 				"Runtime/Core/Public/Modules/",
 				"Editor/UnrealEd/Classes/Factories",
@@ -53,7 +53,7 @@ public class modio : ModuleRules
 		
 		PrivateIncludePaths.AddRange(
 			new string[] {
-				"modio/Private",
+				//"modio/Private",
 				// ... add other private include paths required here ...
 			}
 			);

--- a/Source/modio/modio.Build.cs
+++ b/Source/modio/modio.Build.cs
@@ -33,6 +33,9 @@ public class modio : ModuleRules
 		LoadModio(Target);
 
 		this.bEnableExceptions = true;
+		// Made sure to disable unity builds, as exclusion of some files causes the project to explode
+		// this was we atleast get deterministic builds even if they are slower
+		MinSourceFilesForUnityBuildOverride = 256;
 		
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/ThirdParty/mod.io-sdk-v0.10.1/include/dependencies/nlohmann/json.hpp
+++ b/ThirdParty/mod.io-sdk-v0.10.1/include/dependencies/nlohmann/json.hpp
@@ -14492,7 +14492,7 @@ struct hash<nlohmann::json>
 
 /// specialization for std::less<value_t>
 template<>
-struct less<::nlohmann::detail::value_t>
+struct less< ::nlohmann::detail::value_t >
 {
     /*!
     @brief compare two value_t enum values


### PR DESCRIPTION
unity builds bunch together a lot of .cpp-files to get compile time speedups. And when changing some files, compiles that file separately. That can cause some real issues with modio and cause it not to compile