### PR TITLE
Fix Warnings for >=4.24

### DIFF
--- a/Source/modio/modio.Build.cs
+++ b/Source/modio/modio.Build.cs
@@ -102,8 +102,12 @@ public class modio : ModuleRules
 			string LibrariesPath = Path.Combine(ThirdPartyPath, modio_directory, "lib", "win64");
 			string DLLPath = Path.Combine(ThirdPartyPath, modio_directory, "bin", "win64");
 
+#if UE_4_24_OR_LATER
+			PublicAdditionalLibraries.Add(Path.Combine(LibrariesPath, "modio.lib"));
+#else
 			PublicLibraryPaths.Add(LibrariesPath);
-			PublicAdditionalLibraries.Add("modio.lib");
+			PublicAdditionalLibraries.Add("modio");
+#endif
 			RuntimeDependencies.Add(Path.Combine(DLLPath, "modio.dll"));
 
 			string ProjectBinariesDirectory = Path.Combine(ProjectPath, "Binaries", "Win64");
@@ -123,8 +127,12 @@ public class modio : ModuleRules
 
 			string LibrariesPath = Path.Combine(ThirdPartyPath, modio_directory, "lib", "linux-x64");
 
+#if UE_4_24_OR_LATER
+			PublicAdditionalLibraries.Add(Path.Combine(LibrariesPath, "modio.lib"));
+#else
 			PublicLibraryPaths.Add(LibrariesPath);
 			PublicAdditionalLibraries.Add("modio");
+#endif
 
 			string ProjectBinariesDirectory = Path.Combine(ProjectPath, "Binaries", "Linux");
 			if (!Directory.Exists(ProjectBinariesDirectory))
@@ -139,8 +147,12 @@ public class modio : ModuleRules
 
 			string LibrariesPath = Path.Combine(ThirdPartyPath, modio_directory, "lib", "macOS-x64");
 
+#if UE_4_24_OR_LATER
+			PublicAdditionalLibraries.Add(Path.Combine(LibrariesPath, "modio.lib"));
+#else
 			PublicLibraryPaths.Add(LibrariesPath);
 			PublicAdditionalLibraries.Add("modio");
+#endif
 
 			string ProjectBinariesDirectory = Path.Combine(ProjectPath, "Binaries", "Mac");
 			if (!Directory.Exists(ProjectBinariesDirectory))


### PR DESCRIPTION
Since the 4.24 update there were some warnings regarding the library paths. With using the [UE_4_X_OR_LATER](https://www.unrealengine.com/en-US/blog/unreal-engine-4-17-released#programming) this can be suppressed / fixed while remaining functional for lower versions.

I haven't checked compiling for versions below 4.24 though.