### PR TITLE
Make mod.io settings available in public API

### DIFF
--- a/Source/modio/Public/ModioSettings.h
+++ b/Source/modio/Public/ModioSettings.h
@@ -18,7 +18,7 @@ enum class ERunInEditorOn : uint8
 };
 
 UCLASS(config = Game, defaultconfig)
-class UModioSettings : public UObject
+class MODIO_API UModioSettings : public UObject
 {
   GENERATED_BODY()
 


### PR DESCRIPTION
A simple change to allow the settings class to be used from game code. Useful when the game wants to change the root path